### PR TITLE
Add Brier score overview in Jupyter notebook.

### DIFF
--- a/background.ipynb
+++ b/background.ipynb
@@ -695,7 +695,94 @@
     "\n",
     "## Conclusion\n",
     "\n",
-    "Arsenal went on to win the game 4-1 (which by our prediction only had a 3.4% probability), so the probable outcome was correct, but the probable score of 2-0 was not."
+    "Arsenal went on to win the game 4-1 (which by our prediction only had a 3.4% probability), so the probable outcome was correct, but the probable score of 2-0 was not.\n",
+    "\n",
+    "## Brier Scoring\n",
+    "\n",
+    "A [Brier score](https://en.wikipedia.org/wiki/Brier_score) test how accurate a prediction has been.  In brief, it returns a float between 0 and 2 where zero is an indicatore that your prediction was perfectly accurate and two that your prediction was totally inaccurate.  To use the\n",
+    "[`sklearn.metrics.brier_score_loss`](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.brier_score_loss.html)\n",
+    "function, probabilities of the outcome are provided as a [NumPy](https://en.wikipedia.org/wiki/NumPy) array of three elements:\n",
+    "\n",
+    "1. The predicted probability of a home win.\n",
+    "1. The predicted probability of a score draw.\n",
+    "1. The predicted probability of an away win.\n",
+    "\n",
+    "The actuality is also passed as a NumPy array with the first element being set to 1 indicates a home win, the second element being set to 1 indicates a score draw and the third element being 1 indicates an away win.\n",
+    "\n",
+    "More modern interpretations of the Brier score return a number between 0 and 1.  However we then adjust for the fact that we have a multi-category outcome (home win, score draw, away win), not a binary outcome (win, lose).  Therefore we multiply the result from the `brier_score_loss` function with the number of categories.  This is proven below where we cycle through the outcome of a home win, a score draw and an away win with predictions saying there is a 100% chance of a home win and a 0% for any other outcome.  The home win return a Brier score of 0.0 and the other outcomes return 2.0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.0\n",
+      "2.0\n",
+      "2.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn.metrics import brier_score_loss\n",
+    "\n",
+    "# Set some constants\n",
+    "HOME_WIN = np.array([1, 0, 0])\n",
+    "SCORE_DRAW = np.array([0, 1, 0])\n",
+    "AWAY_WIN = np.array([0, 0, 1])\n",
+    "\n",
+    "y_prob = np.array([1, 0, 0])\n",
+    "\n",
+    "for y_true in [HOME_WIN, SCORE_DRAW, AWAY_WIN]:\n",
+    "    bs = brier_score_loss(y_true, y_prob)\n",
+    "    bs *= len(y_prob)\n",
+    "    print(bs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To compare this to what happend between Arsenal and Stoke, where the predicted probabilities were 70.02, 18.43, 9.56 for a home win, a score draw and an away win respectively and we now know that it was a home win, we can calculate the Brier with the following code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.13\n",
+      "1.16\n",
+      "1.34\n"
+     ]
+    }
+   ],
+   "source": [
+    "y_prob = np.array([70.02, 18.43, 9.56])\n",
+    "\n",
+    "# Adjust the values as they need to be between 0.0 and 1.0\n",
+    "y_prob /= 100.0\n",
+    "\n",
+    "for y_true in [HOME_WIN, SCORE_DRAW, AWAY_WIN]:\n",
+    "    bs = brier_score_loss(y_true, y_prob)\n",
+    "    bs *= len(y_prob)\n",
+    "    print(round(bs, 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This shows a Brier score of 0.13 for a home win (the actual result with a probability of 70.02%), 1.16 if there had been a draw (18.43% probability) and 1.34 if the outcome had been an away win (9.56%) probability."
    ]
   }
  ],


### PR DESCRIPTION
This is simply a documentation update and can be previewed in the _Brier Scoring_ section at https://github.com/FootyStats/footy/blob/feature/briers_score/background.ipynb

As previously discussed about Brier scores it was originally published as a score between 0 and 2.  More modern implementations take a score between 0 and 1, but don't take into account multiple categories.  As we will have at least three categories (home win, score draw and away win) we need to use the original implementation.  This will be especially true when scoring the predicted number of goals (which will the probability of zero through six goals being scored by either team).

This PR is part of the work towards #4.