### PR TITLE
Team Class Tests Not Running on Travis CI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -510,17 +510,23 @@ The notation of a score draw outcome.
     List of int
 
 
+# footy.domain.Competition
+
 Competition - Data structure for a competition/league.
 
 
 ### class footy.domain.Competition.Competition()
 Competition - Data structure for a competition/league.
 
+# footy.domain.Result
+
 Result - Data structure for a result.
 
 
 ### class footy.domain.Result.Result()
 Result - Data structure for a result.
+
+# footy.domain.Team
 
 Result - Data structure for a team.
 
@@ -638,3 +644,75 @@ Getter method for property team_name.
 * **Return type**
 
     str
+
+
+# footy.domain.Fixture
+
+Fixture - Data structure for a fixture.
+
+
+### class footy.domain.Fixture.Fixture()
+Fixture - Data structure for a fixture.
+
+# footy.engine.PredictionEngine
+
+Prediction Engine - Engine to predict the result of future fixtures.
+
+
+### class footy.engine.PredictionEngine.PredictionEngine(competition)
+Prediction Engine - Engine to predict the result of future fixtures.
+
+
+#### predict_results(competition)
+Generate the predictions for fixtures within a competition.
+
+
+* **Returns**
+
+    Enriched competition with most recent predictions.
+
+
+
+* **Return type**
+
+    Competition
+
+
+# footy.engine.UpdateEngine
+
+Prediction Engine - Update the data model with the most resent fixtures and results.
+
+
+### class footy.engine.UpdateEngine.UpdateEngine()
+Prediction Engine - Update the data model with the most resent fixtures and results.
+
+
+#### get_competition(code)
+Retrieve data for the supplied competition code.
+
+
+* **Returns**
+
+    A Competition object with the most recent fixtures and results for the supplied competition code.
+
+
+
+* **Return type**
+
+    Competition
+
+
+
+#### update_competition(competition)
+Retrieve data and enrich the supplied competition with the most recent fixtures and results.
+
+
+* **Returns**
+
+    A Competition object with the most recent fixtures and results for the supplied competition code.
+
+
+
+* **Return type**
+
+    Competition

--- a/footy/domain/Fixture.py
+++ b/footy/domain/Fixture.py
@@ -1,7 +1,7 @@
 """Fixture - Data structure for a fixture."""
 
-from footy.footy.domain import Result
-from footy.footy.domain import Team
+from footy.domain import Result
+from footy.domain import Team
 
 
 class Fixture:

--- a/footy/engine/PredictionEngine.py
+++ b/footy/engine/PredictionEngine.py
@@ -1,6 +1,6 @@
 """Prediction Engine - Engine to predict the result of future fixtures."""
 # calculate the results for fixtures
-from footy.footy.domain import Competition
+from footy.domain import Competition
 
 
 class PredictionEngine:

--- a/footy/engine/UpdateEngine.py
+++ b/footy/engine/UpdateEngine.py
@@ -1,6 +1,6 @@
 """Prediction Engine - Update the data model with the most resent fixtures and results."""
 
-from footy.footy.domain import Competition
+from footy.domain import Competition
 
 
 class UpdateEngine:

--- a/index.rst
+++ b/index.rst
@@ -10,15 +10,33 @@ Footy
 =====
 .. automodule:: footy
    :members:
+
+footy.domain.Competition
+========================
 .. automodule:: footy.domain.Competition
    :members:
+
+footy.domain.Result
+===================
 .. automodule:: footy.domain.Result
    :members:
+
+footy.domain.Team
+=================
 .. automodule:: footy.domain.Team
    :members:
+
+footy.domain.Fixture
+====================
 .. automodule:: footy.domain.Fixture
    :members:
+
+footy.engine.PredictionEngine
+=============================
 .. automodule:: footy.engine.PredictionEngine
    :members:
-.. automodule:: footy.domain.UpdateEngine
+
+footy.engine.UpdateEngine
+=========================
+.. automodule:: footy.engine.UpdateEngine
    :members:

--- a/tests/domain/test_Team.py
+++ b/tests/domain/test_Team.py
@@ -1,6 +1,6 @@
 import unittest
 
-from footy.footy.domain.Team import Team
+from footy.domain.Team import Team
 
 
 class MyTestCase(unittest.TestCase):


### PR DESCRIPTION
# Overview
This PR fixes #22 and also fixes some Sphinx issues.

# Fix CI Tests
I renamed the file containing the unit tests to match the expected file name pattern (see https://docs.pytest.org/en/stable/getting-started.html#run-multiple-tests).  The unit tests for the Team class are now being executed (see https://travis-ci.com/github/FootyStats/footy/builds/188024107).

# Sphinx Formatting
Now the tests are running, they were failing due to the name of the modules being provided.  Fixed these and set the headers for the new modules in `index.rst`.  These can now be previewed at:

- https://github.com/FootyStats/footy/blob/bugfix/test_team_tests_not_running/docs/index.md#footydomaincompetition
- https://github.com/FootyStats/footy/blob/bugfix/test_team_tests_not_running/docs/index.md#footydomainresult
- https://github.com/FootyStats/footy/blob/bugfix/test_team_tests_not_running/docs/index.md#footydomainteam
- https://github.com/FootyStats/footy/blob/bugfix/test_team_tests_not_running/docs/index.md#footydomainfixture
- https://github.com/FootyStats/footy/blob/bugfix/test_team_tests_not_running/docs/index.md#footyenginepredictionengine
- https://github.com/FootyStats/footy/blob/bugfix/test_team_tests_not_running/docs/index.md#footyengineupdateengine

