### PR TITLE
Ensure the fixture method of Footy returns a Fixture object (#14).

### DIFF
--- a/background.ipynb
+++ b/background.ipynb
@@ -681,8 +681,8 @@
     "home_team = f.get_team('Arsenal')\n",
     "away_team = f.get_team('Stoke')\n",
     "response = f.fixture(home_team, away_team)\n",
-    "home_team_goals_probability = response['home_team_goals_probability']\n",
-    "away_team_goals_probability = response['away_team_goals_probability']\n",
+    "home_team_goals_probability = response.home_team_goals_probability()\n",
+    "away_team_goals_probability = response.away_team_goals_probability()\n",
     "\n",
     "fig, ax = plt.subplots()\n",
     "width = 0.3\n",
@@ -700,7 +700,7 @@
     "fig.tight_layout()\n",
     "plt.show()\n",
     "\n",
-    "response['final_score_probabilities']"
+    "response.final_score_probabilities()"
    ]
   },
   {
@@ -742,7 +742,7 @@
    ],
    "source": [
     "labels = [f'{home_team.team_name} Win', 'Draw', f'{away_team.team_name} Win']\n",
-    "sizes = response['outcome_probabilities']\n",
+    "sizes = response.outcome_probabilities()\n",
     "\n",
     "fig1, ax1 = plt.subplots()\n",
     "ax1.pie(sizes, labels=labels, autopct='%1.1f%%',\n",
@@ -834,7 +834,7 @@
     }
    ],
    "source": [
-    "y_prob = np.array(response['outcome_probabilities'])\n",
+    "y_prob = np.array(response.outcome_probabilities())\n",
     "\n",
     "# Adjust the values as they need to be between 0.0 and 1.0\n",
     "y_prob /= 100.0\n",

--- a/docs/index.md
+++ b/docs/index.md
@@ -292,36 +292,13 @@ Calculate the probabilities of a fixture between two teams.
 
 * **Returns**
 
-    If there is enough data for any probabilities to be calculated,
-    the dictionary will contain elements called:
-
-    outcome_probabilities: A list of three floats indicating (with
-    values between 0.0 and 1.0) the probability of a home win, a
-    score draw or an away win respectively.
-
-    home_team_goals_probability: A list of seven floats indicating
-    (with values between 0.0 and 1.0) the probability of the home team
-    scoring between 0 and 6 goals.
-
-    away_team_goals_probability: A list of seven floats indicating
-    (with values between 0.0 and 1.0) the probability of the away team
-    scoring between 0 and 6 goals.
-
-    final_score_probabilities:  A Pandas DataFrame with each row
-    containing the number of goals scored by the home team, the number
-    of goals scored by the away team and the probability of that final
-    score.  The table will be sorted with the most probable results
-    descending.
-
-    If there is not enough data to calculate the probabilities, the
-    dictionary returned by this function will be empty.
-
+    A fixture containing the predicted probabilities (if available).
 
 
 
 * **Return type**
 
-    dict
+    footy.domain.Fixture.Fixture
 
 
 
@@ -797,6 +774,58 @@ Getter method for property away_team.
 
 
 
+#### away_team_goals_probability(away_team_goals_probability=None)
+Get or set the away_team_goals_probability of the fixture.
+
+
+* **Parameters**
+
+    **away_team_goals_probability** (*list of float*) – A list of floats indicating (with values between 0.0 and 1.0) the probability of between zero and six
+    goals being scored by the away team.
+
+
+
+* **Returns**
+
+    A list of floats indicating (with values between 0.0 and 1.0) the probability of between zero and six
+    goals being scored by the away team.  If there is not enough data to calculate the probabilities, this
+    will return None.
+
+
+
+* **Return type**
+
+    list of float
+
+
+
+#### final_score_probabilities(final_score_probabilities=None)
+Get or set the final_score_probabilities of the fixture.
+
+
+* **Parameters**
+
+    **final_score_probabilities** (*DataFrame*) – A Pandas DataFrame with each row containing the number of goals scored by the home team, the number of
+    goals scored by the away team and the probability of that final score. The table will be sorted with the
+    most probable results descending.
+
+
+
+* **Returns**
+
+    A Pandas DataFrame with each row containing the number of goals scored by the home team, the number of
+    goals scored by the away team and the probability of that final score. The table will be sorted with the
+    most probable results descending.  If there is not enough data to calculate the probabilities, this
+    will return None.
+
+
+
+* **Return type**
+
+    DataFrame
+
+
+
 #### property home_team()
 Getter method for property home_team.
 
@@ -810,6 +839,56 @@ Getter method for property home_team.
 * **Return type**
 
     Team
+
+
+
+#### home_team_goals_probability(home_team_goals_probability=None)
+Get or set the home_team_goals_probability of the fixture.
+
+
+* **Parameters**
+
+    **home_team_goals_probability** (*list of float*) – A list of floats indicating (with values between 0.0 and 1.0) the probability of between zero and six
+    goals being scored by the home team.
+
+
+
+* **Returns**
+
+    A list of floats indicating (with values between 0.0 and 1.0) the probability of between zero and six
+    goals being scored by the home team.  If there is not enough data to calculate the probabilities, this
+    will return None.
+
+
+
+* **Return type**
+
+    list of float
+
+
+
+#### outcome_probabilities(outcome_probabilities=None)
+Get or set the outcome_probabilities of the fixture.
+
+
+* **Parameters**
+
+    **outcome_probabilities** (*list of float*) – A list of three floats indicating (with values between 0.0 and 1.0) the probability of a home win, a score
+    draw or an away win respectively.
+
+
+
+* **Returns**
+
+    A list of three floats indicating (with values between 0.0 and 1.0) the probability of a home win, a score
+    draw or an away win respectively.  If not enough data is available to calculate the probabilities the
+    will return None.
+
+
+
+* **Return type**
+
+    list of float
 
 
 

--- a/footy/domain/Fixture.py
+++ b/footy/domain/Fixture.py
@@ -16,7 +16,7 @@ class Fixture:
         home_team : Team
             The home team playing in this fixture.
         away_team : Team
-            The home team playing in this fixture.
+            The away team playing in this fixture.
         status : str, optional
             The status of this fixture. Defaults to 'SCHEDULED'.
         utc_start : str, optional
@@ -29,6 +29,10 @@ class Fixture:
         self._status = status
         self._utc_start = utc_start
         self._result = result or Result()
+        self._outcome_probabilities = None
+        self._home_team_goals_probability = None
+        self._away_team_goals_probability = None
+        self._final_score_probabilities = None
 
     @property
     def home_team(self):
@@ -149,3 +153,89 @@ class Fixture:
             The value you wish to set the result property to.
         """
         self._result = result
+
+    def outcome_probabilities(self, outcome_probabilities=None):
+        """
+        Get or set the outcome_probabilities of the fixture.
+
+        Parameters
+        ----------
+        outcome_probabilities: list of float
+            A list of three floats indicating (with values between 0.0 and 1.0) the probability of a home win, a score
+            draw or an away win respectively.
+
+        Returns
+        -------
+        list of float
+            A list of three floats indicating (with values between 0.0 and 1.0) the probability of a home win, a score
+            draw or an away win respectively.  If not enough data is available to calculate the probabilities the
+            will return None.
+        """
+        if outcome_probabilities is not None:
+            self._outcome_probabilities = outcome_probabilities
+        return self._outcome_probabilities
+
+    def home_team_goals_probability(self, home_team_goals_probability=None):
+        """
+        Get or set the home_team_goals_probability of the fixture.
+
+        Parameters
+        ----------
+        home_team_goals_probability: list of float
+            A list of floats indicating (with values between 0.0 and 1.0) the probability of between zero and six
+            goals being scored by the home team.
+
+        Returns
+        -------
+        list of float
+            A list of floats indicating (with values between 0.0 and 1.0) the probability of between zero and six
+            goals being scored by the home team.  If there is not enough data to calculate the probabilities, this
+            will return None.
+        """
+        if home_team_goals_probability is not None:
+            self._home_team_goals_probability = home_team_goals_probability
+        return self._home_team_goals_probability
+
+    def away_team_goals_probability(self, away_team_goals_probability=None):
+        """
+        Get or set the away_team_goals_probability of the fixture.
+
+        Parameters
+        ----------
+        away_team_goals_probability: list of float
+            A list of floats indicating (with values between 0.0 and 1.0) the probability of between zero and six
+            goals being scored by the away team.
+
+        Returns
+        -------
+        list of float
+            A list of floats indicating (with values between 0.0 and 1.0) the probability of between zero and six
+            goals being scored by the away team.  If there is not enough data to calculate the probabilities, this
+            will return None.
+        """
+        if away_team_goals_probability is not None:
+            self._away_team_goals_probability = away_team_goals_probability
+        return self._away_team_goals_probability
+
+    def final_score_probabilities(self, final_score_probabilities=None):
+        """
+        Get or set the final_score_probabilities of the fixture.
+
+        Parameters
+        ----------
+        final_score_probabilities: DataFrame
+            A Pandas DataFrame with each row containing the number of goals scored by the home team, the number of
+            goals scored by the away team and the probability of that final score. The table will be sorted with the
+            most probable results descending.
+
+        Returns
+        -------
+        DataFrame
+            A Pandas DataFrame with each row containing the number of goals scored by the home team, the number of
+            goals scored by the away team and the probability of that final score. The table will be sorted with the
+            most probable results descending.  If there is not enough data to calculate the probabilities, this
+            will return None.
+        """
+        if final_score_probabilities is not None:
+            self._final_score_probabilities = final_score_probabilities
+        return self._final_score_probabilities

--- a/tests/test_footy.py
+++ b/tests/test_footy.py
@@ -87,7 +87,7 @@ class TestFootyClass(unittest.TestCase):
         # No games played, so we don't expect any probability data to
         # be available.
         response = footy_obj.fixture(team_a, team_b)
-        self.assertIsNone(response)
+        self.assertIsNone(response.outcome_probabilities())
 
         # Team D beats A 2 - 0 away.
         footy_obj.add_team(Team('Team A', 0, 2, 1, 0, 0))
@@ -110,7 +110,7 @@ class TestFootyClass(unittest.TestCase):
         # B and A have not played away.  Therefore still expecting not
         # to have enough data to track probabilities.
         response = footy_obj.fixture(footy_obj.get_team('Team A'), footy_obj.get_team('Team B'))
-        self.assertIsNone(response)
+        self.assertIsNone(response.outcome_probabilities())
 
         # Team D hosts B and beats them 2 - 0.
         goals_for = footy_obj.get_team('Team B').goals_for + 0
@@ -178,8 +178,8 @@ class TestFootyClass(unittest.TestCase):
         # Now we do have enough data to predict fixtures.  In this case we
         # expect Team D to beat A at home.
         response = footy_obj.fixture(footy_obj.get_team('Team D'), footy_obj.get_team('Team A'))
-        self.assertIsNotNone(response)
-        outcome_probabilities = response['outcome_probabilities']
+        self.assertIsNotNone(response.outcome_probabilities())
+        outcome_probabilities = response.outcome_probabilities()
         self.assertGreater(outcome_probabilities[0], outcome_probabilities[1])
         self.assertGreater(outcome_probabilities[0], outcome_probabilities[2])
 
@@ -223,7 +223,7 @@ class TestFootyClass(unittest.TestCase):
         """
         footy = self.footy_under_test_producer()
         response = footy.fixture(footy.get_team(home_team_name), footy.get_team(away_team_name))
-        outcome_probabilities = response['outcome_probabilities']
+        outcome_probabilities = response.outcome_probabilities()
 
         # We allow some wriggle room for the values calculated.  This is
         # because the maximum number of goals we test up to is six.  However,
@@ -244,7 +244,7 @@ class TestFootyClass(unittest.TestCase):
                 delta=delta
             )
 
-        final_score_probabilities = response['final_score_probabilities']
+        final_score_probabilities = response.final_score_probabilities()
         final_score_probabilities = final_score_probabilities.values.tolist()
         most_likely_final_score = final_score_probabilities[0]
         self.assertEqual(most_likely_final_score[0],


### PR DESCRIPTION
**Overview**

This PR ensures that instead of a complicated dictionary being returned by the `fixture` method of the Footy class, a Fixture object is instead.  I have updated all the tests, the docstrings and the back ground Jupyter notebook.  The method will always return a Fixture object, but if there is enough data to calculate the probabilities, it will enrich the object with those details.

**Available Previews**

- Package documentation https://github.com/FootyStats/footy/blob/feature/Issue14-Fixture-Object/docs/index.md#welcome-to-footys-documentation
- Background Jupyter Notebook https://github.com/FootyStats/footy/blob/feature/Issue14-Fixture-Object/background.ipynb

**Possible Areas of Contention**

- I use get/set methods, I can convert to the more Java like approach if preferred.

**Issues Fixed**

- Fixes #14 